### PR TITLE
restore keeping submissions in chronological order

### DIFF
--- a/commands/events.py
+++ b/commands/events.py
@@ -456,7 +456,7 @@ Denied reports: {}
                     status= self.status,
                     participants= self.participants
                 )
-                f.write(json.dumps(save_dict, indent=4, skipkeys=True, sort_keys=True, ensure_ascii=False))
+                f.write(json.dumps(save_dict, indent=4, skipkeys=True, sort_keys=False, ensure_ascii=False))
             except IOError as ex:
                 print(":rotating_light: <@110813477156720640> save to disc: {file}\nstrerror: {strerror}".format(file='eventstats.json', strerror=ex.strerror))
                 traceback.print_exc()


### PR DESCRIPTION
bit late but i just remembered i forgot to fix this, now the bot will keep all submissions in his list in chronological order between reboots again, also should speed up saving as it doesn't have to sort them all (although it's probably minimal)