### PR TITLE
event importing

### DIFF
--- a/commands/announce.py
+++ b/commands/announce.py
@@ -21,7 +21,7 @@ class announce(Plugin):
             event.msg.delete()
 
     @Plugin.command('employee', "<new_employee:str>")
-    def make_employee(self, event, new_employee:str):
+    def make_employee(self, event, new_employee):
         if any(role == 197042389569765376  for role in event.member.roles):
             if new_employee.startswith("<@"):
                 id = new_employee[2:-1]
@@ -221,20 +221,19 @@ class announce(Plugin):
                             break
             event.msg.reply("Unlock command has successfully completed!")
             
-       @Plugin.command('a11y')
+    @Plugin.command('a11y')
     def grant_role(self, event):
-        
-        if 441739649753546764 in event.member.roles:
-	    event.member.remove_role(441739649753546764)
-	    self.botlog(event, ":thumbsdown: <@" +str(event.author.id)+ "> removed the A11y role from themselves.")
-	    event.msg.reply("<@" +str(event.author.id)+ "> I have removed the A11y (Accessibility Role) from you. Use the same command again to add the role to yourself.").after(5).delete()
-	    event.msg.delete()
-	else:
-	    event.member.add_role(441739649753546764)
-	    self.botlog(event, ":thumbsup: <@" +str(event.author.id)+ "> added the A11y role to themselves.")
-	    event.msg.reply("<@" +str(event.author.id)+ "> I have added the A11y (Accessibility Role) to you. Use the same command again to remove the role from yourself.").after(5).delete()
-	    event.msg.delete()
 
+        if 441739649753546764 in event.member.roles:
+            event.member.remove_role(441739649753546764)
+            self.botlog(event, ":thumbsdown: <@" +str(event.author.id)+ "> removed the A11y role from themselves.")
+            event.msg.reply("<@" +str(event.author.id)+ "> I have removed the A11y (Accessibility Role) from you. Use the same command again to add the role to yourself.").after(5).delete()
+            event.msg.delete()
+        else:
+            event.member.add_role(441739649753546764)
+            self.botlog(event, ":thumbsup: <@" +str(event.author.id)+ "> added the A11y role to themselves.")
+            event.msg.reply("<@" +str(event.author.id)+ "> I have added the A11y (Accessibility Role) to you. Use the same command again to remove the role from yourself.").after(5).delete()
+            event.msg.delete()
 
     def checkPerms(self, event, type):
         # get roles from the config

--- a/commands/events.py
+++ b/commands/events.py
@@ -413,7 +413,7 @@ Denied reports: {}
         channel = event.guild.channels[channel_id]
         messages = []
         message_info = dict()
-        for message in channel.messages_iter(chunk_size=2, direction=MessageIterator.Direction.UP, before=event.msg.id):
+        for message in channel.messages_iter(chunk_size=100, direction=MessageIterator.Direction.UP, before=event.msg.id):
             messages.append(message.id)
             message_info[message.id] = {
                 "author_id": str(message.author.id),
@@ -428,6 +428,7 @@ Denied reports: {}
             return result.group("url") if result is not None else None
 
         invalid = 0
+        dupes = 0
         for m_id in messages:
             link = get_url(message_info[m_id]["content"])
             if link is None:
@@ -443,6 +444,7 @@ Denied reports: {}
                     self.bot.client.api.channels_messages_reactions_create(int(channel_id), m_id, "❓")
                 elif trello_info['id'] in self.reported_cards.keys(): # already reported
                     state = "Dupe"
+                    dupes += 1
                     if trello_id not in self.dupes.keys():
                         self.dupes[trello_id] = 1
                     else:
@@ -473,9 +475,9 @@ Denied reports: {}
         event.msg.reply("""
 Data import complete
 Imported entries: {}
-Dupes encountered: {}
+Dupes encountered: {} ({} tickets)
 Invalid entries skipped: {}
-""".format(len(self.reported_cards.keys()), len(self.dupes.keys()), invalid))
+""".format(len(self.reported_cards.keys()), dupes, len(self.dupes.keys()), invalid))
         #override event channel from import
         self.config.event_channel = int(channel_id)
         self.end_event(event)

--- a/commands/events.py
+++ b/commands/events.py
@@ -1,12 +1,15 @@
+# coding=utf-8
 import json
 import os.path
 import time
 import traceback
 from datetime import datetime
+import re
 
 from disco.api.http import APIException
 from disco.bot import Plugin
 from disco.util import sanitize
+from disco.types.channel import MessageIterator
 
 from commands.config import EventsPluginConfig
 from util import TrelloUtils
@@ -16,13 +19,14 @@ from util import TrelloUtils
 class Events(Plugin):
 
     def __init__(self, bot, config):
-        super().__init__(bot, config)
+        super(Events, self).__init__(bot, config)
         #initialize
         self.queued = False
         self.saving = False
         self.status = "Scheduled"
         self.participants = dict()
         self.reported_cards = dict()
+        self.dupes = dict()
 
     def load(self, ctx):
         super(Events, self).load(ctx)
@@ -33,7 +37,7 @@ class Events(Plugin):
         super(Events, self).unload(ctx)
 
     @Plugin.command("submit", "[submission:str...]")
-    def template(self, event, submission:str=None):
+    def template(self, event, submission=None):
         """Make a new submission"""
         if self.status != "Started":
             return #no event going on, pretend nothing happened #noleeks
@@ -344,7 +348,7 @@ Denied reports: {}
                     self.participants[str(report_info["author_id"])], str(event.author)))
             return
         dmessage = event.guild.channels[self.config.event_channel].get_message(report_info["message_id"])
-        content:str = dmessage.content
+        content = dmessage.content
         new_message = ""
         lines = content.splitlines()
         if section == "destination":
@@ -390,6 +394,92 @@ Denied reports: {}
         del self.reported_cards[trello_info["id"]]
         event.msg.reply(":warning: Submission has been nuked <@{}>!".format(event.author.id))
         self.botlog(event, ":wastebasket: {} has removed <https://trello.com/c/{}>".format(str(event.author), trello_info['shortLink']))
+
+
+    @Plugin.command("import", "<channel_id:snowflake>", group="event")
+    def import_event(self, event, channel_id):
+        if not self.checkPerms(event, "admin"):
+            return
+        if self.status != "Scheduled":
+            event.msg.reply("I have event data loaded, import aborted to prevent data corruption, please remove/rename the current eventstats file and reboot")
+            return
+        if not channel_id in event.guild.channels.keys():
+            event.msg.reply("I cannot find a channel with that ID")
+            return
+
+
+        # we're importing so no enforced anti duping, collect all for chronological processing
+        event.msg.reply("Starting import...")
+        channel = event.guild.channels[channel_id]
+        messages = []
+        message_info = dict()
+        for message in channel.messages_iter(chunk_size=2, direction=MessageIterator.Direction.UP, before=event.msg.id):
+            messages.append(message.id)
+            message_info[message.id] = {
+                "author_id": str(message.author.id),
+                "author_name": str(message.author),
+                "content": message.content
+            }
+        messages.sort()
+        print("Collected {} messages for processing".format(len(messages)))
+
+        def get_url(m):
+            result = re.search("(?P<url>https?://trello.com/c/[^\s]+)", m)
+            return result.group("url") if result is not None else None
+
+        invalid = 0
+        for m_id in messages:
+            link = get_url(message_info[m_id]["content"])
+            if link is None:
+                state = "Invalid"
+                invalid += 1
+                self.bot.client.api.channels_messages_reactions_create(int(channel_id), m_id, "❓")
+            else:
+                trello_info = TrelloUtils.getCardInfo(None, link)
+                trello_id = trello_info["id"]
+                if trello_info in (False, None) or trello_info["idBoard"] not in self.config.boards.keys():
+                    state = "Invalid"
+                    invalid += 1
+                    self.bot.client.api.channels_messages_reactions_create(int(channel_id), m_id, "❓")
+                elif trello_info['id'] in self.reported_cards.keys(): # already reported
+                    state = "Dupe"
+                    if trello_id not in self.dupes.keys():
+                        self.dupes[trello_id] = 1
+                    else:
+                        self.dupes[trello_id] += 1
+                    self.bot.client.api.channels_messages_reactions_create(int(channel_id), m_id, "🚫")
+                else:
+                    board = self.config.boards[trello_info["idBoard"]]
+                    if trello_info["idList"] not in board["lists"] or trello_info["closed"] is True:
+                        state = "Invalid"
+                        invalid += 1
+                        self.bot.client.api.channels_messages_reactions_create(int(channel_id), m_id, "❓")
+                    else:
+                        state = "Valid"
+
+            print("{} - {}".format(m_id, state))
+
+            if state == "Valid":
+                self.reported_cards[trello_info['id']] = dict(
+                    author_id=message_info[m_id]["author_id"],
+                    board=trello_info["idBoard"],
+                    list=trello_info["idList"],
+                    message_id=m_id,
+                    status="Submitted",
+                )
+                if message_info[m_id]["author_id"] not in self.participants.keys():
+                    self.participants[message_info[m_id]["author_id"]] = message_info[m_id]["author_name"]
+
+        event.msg.reply("""
+Data import complete
+Imported entries: {}
+Dupes encountered: {}
+Invalid entries skipped: {}
+""".format(len(self.reported_cards.keys()), len(self.dupes.keys()), invalid))
+        #override event channel from import
+        self.config.event_channel = int(channel_id)
+        self.end_event(event)
+
 
 
     @Plugin.command("next")
@@ -449,12 +539,13 @@ Denied reports: {}
             else:
                 return
         self.saving = True
-        with open("eventstats.json", "w", encoding='utf8') as f:
+        with open("eventstats.json", "w") as f:
             try:
                 save_dict = dict(
                     reported_cards= self.reported_cards,
                     status= self.status,
-                    participants= self.participants
+                    participants= self.participants,
+                    dupes= self.dupes
                 )
                 f.write(json.dumps(save_dict, indent=4, skipkeys=True, sort_keys=False, ensure_ascii=False))
             except IOError as ex:
@@ -465,13 +556,14 @@ Denied reports: {}
     def load_event_stats(self):
         if not os.path.isfile("eventstats.json"):
             return
-        with open('eventstats.json', "r", encoding='utf8') as f:
+        with open('eventstats.json', "r") as f:
             try:
                 event_stats = f.read()
                 event_stats_parsed = json.loads(event_stats)
                 self.reported_cards = event_stats_parsed.get("reported_cards",dict())
                 self.status = event_stats_parsed.get("status", "Scheduled")
                 self.participants = event_stats_parsed.get("participants", dict())
+                self.dupes = event_stats_parsed.get("dupes", dict())
             except IOError as ex:
                 print(":rotating_light: <@110813477156720640> load from disc: {file}\nstrerror: {strerror}".format(file='eventstats.json', strerror=ex.strerror))
                 traceback.print_exc()

--- a/util/TrelloUtils.py
+++ b/util/TrelloUtils.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import json
 
 import requests
@@ -15,7 +16,7 @@ def getCardInfo(event, id):
         response = requests.request("GET", "https://api.trello.com/1/cards/{}".format(id))
         try:
             card_cache[id] = json.loads(response.text)
-        except json.JSONDecodeError as ex:
+        except ValueError as ex:
             return None
     return card_cache[id]
 


### PR DESCRIPTION
just a thing i made to help with the current event, adds a new command `+event import <channel_id>`

this requires to have no event data to be loaded (so current json file needs to be renamed or removed and the bot restarted so it has a blank slate) and the config has to be updated to set the event channel entry to the new one

this will make it process all messages in the channel as new event entries (in chronological order), during import all dupes will be marked with a 🚫 reaction, invalid messages that could not be processed with ❓

after the import completes it will end the event (as if `event end` was invoked) and everything will be prepped and handed like last time (including scoring so if you want board score weights to be the same or different that also needs changing in the config)

bonus: this has been tested on python 2.7.9 (i know the server is 2.7.6 but running that version is a lot more complex as it's TSL libs are so outdated it cannot connect to any pip repo to install anything and manually patching that is a lot more work, this version is close enough there shouldn't be any surprises this time)

![image](https://user-images.githubusercontent.com/5206666/42732600-b3610fcc-8824-11e8-89f4-98a63f0c6851.png)
