### PR TITLE
Fixed a minor typo

### DIFF
--- a/commands/experience.py
+++ b/commands/experience.py
@@ -311,7 +311,7 @@ class ExperiencePlugin(Plugin):
                 "xp": user["xp"] - store_item["cost"]
             }
         })
-        event.msg.reply(":ok_hand: item purchased! Note that if them item you purchased needs to be shipped, you have "
+        event.msg.reply(":ok_hand: item purchased! Note that if the item you purchased needs to be shipped, you have "
                         "to contact Dabbit Prime#0896 via DMs to provide a mailing address.").after(15).delete()
         prize_log_channel = self.bot.client.api.channels_get(self.config.channels["prize_log"])
         prize_log_channel.send_message("{name} (`{id}`) bought {title}!".format(


### PR DESCRIPTION
When you purchase something through announceBot, the bot said the following: ":ok_hand: item purchased! Note that if them (<-- Typo) item you purchased needs to be shipped, you have to contact Dabbit Prime#0896 via DMs to provide a mailing address." You can see it here:  https://i.imgur.com/L9fIpsF.png 

So I went ahead and fixed the typo.