### PR TITLE
major cleaning up of permissions and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/
 eventstats.json
 eval.py
 *.png
+config.yaml

--- a/commands/announce.py
+++ b/commands/announce.py
@@ -2,6 +2,7 @@ from disco.api.http import APIException
 from disco.bot import Plugin
 
 from commands.config import AnnounceBotConfig
+from util.GlobalHandlers import command_wrapper, log_to_bot_log
 
 
 @Plugin.with_config(AnnounceBotConfig)
@@ -12,13 +13,13 @@ class announce(Plugin):
     def unload(self, ctx):
         super(announce, self).unload(ctx)
 
+    # just wanted a standard ping command
     @Plugin.command('evilping')
-    #just wanted a standard ping command
+    @command_wrapper(log=False)
     def check_bot_heartbeat(self, event):
-        if self.checkPerms(event, "mod"):
-            event.msg.reply('Evil pong!').after(1).delete()
-            self.botlog(event, ":evilDabbit: "+str(event.msg.author)+" used the EvilPing command.")
-            event.msg.delete()
+        event.msg.reply('Evil pong!').after(1).delete()
+        log_to_bot_log(self.bot, ":evilDabbit: "+str(event.msg.author)+" used the EvilPing command.")
+        event.msg.delete()
 
     @Plugin.command('employee', "<new_employee:str>")
     def make_employee(self, event, new_employee):
@@ -41,12 +42,13 @@ class announce(Plugin):
                     event.msg.reply("Unable to find that person")
         else:
             event.msg.reply(":lock: You do not have permission to use this command!")
-            self.botlog(event, ":warning: {} tried to use a command they do not have permission to use.".format(str(event.msg.author)))
+            log_to_bot_log(self.bot, ":warning: {} tried to use a command they do not have permission to use.".format(str(event.msg.author)))
 
 
 
 
     @Plugin.command('announce', '<role_to_ping:str> [announcement_message:str...]')
+    @command_wrapper(perm_lvl=2)
     def Make_an_Announcement(self, event, role_to_ping, announcement_message):
 
         role_Name = role_to_ping.lower()
@@ -63,28 +65,27 @@ class announce(Plugin):
         message_to_announce = "<@&" + Role_as_a_string + "> " + announcement_message
         admin_only_channel = self.config.channel_IDs['mod_Channel']
 
-        #Make sure only an admin can do it
-        if self.checkPerms(event, "admin"):
-            # make sure it's in the right channel
-            if event.channel.id != admin_only_channel:
-                print("The command was not run in the proper channel")
-                return
+        # make sure it's in the right channel
+        if event.channel.id != admin_only_channel:
+            print("The command was not run in the proper channel")
+            return
 
-            if Is_Role_Mentionable == False:
-                role_Name = str(role_Name)
-                Channel_to_announce_in = self.config.channel_IDs[role_Name]
-                Channel_to_announce_in = int(Channel_to_announce_in)
-                Role_To_Make_Mentionable.update(mentionable=True)
-                self.bot.client.api.channels_messages_create(Channel_to_announce_in, message_to_announce)
-                Role_To_Make_Mentionable.update(mentionable=False)
-                return
+        if Is_Role_Mentionable == False:
+            role_Name = str(role_Name)
+            Channel_to_announce_in = self.config.channel_IDs[role_Name]
+            Channel_to_announce_in = int(Channel_to_announce_in)
+            Role_To_Make_Mentionable.update(mentionable=True)
+            self.bot.client.api.channels_messages_create(Channel_to_announce_in, message_to_announce)
+            Role_To_Make_Mentionable.update(mentionable=False)
+            return
 
-            else:
-                Role_To_Make_Mentionable.update(mentionable=False)
-                event.msg.reply("This role was already mentionable. I made it unmentionable, please try again.")
-                return
+        else:
+            Role_To_Make_Mentionable.update(mentionable=False)
+            event.msg.reply("This role was already mentionable. I made it unmentionable, please try again.")
+            return
 
     @Plugin.command('update', '<channel_id_to_change>:int> <message_ID_to_edit:int> [edited_announcemented_message:str...]')
+    @command_wrapper(perm_lvl=2)
     def edit_most_recent_announcement(self, event, channel_id_to_change, message_ID_to_edit, edited_announcemented_message):
 
         #Variables
@@ -96,23 +97,19 @@ class announce(Plugin):
             return
 
         #make sure only an admin can use this command and if so, execute
-        if any(role in self.config.admin_Role_IDs.values() for role in event.member.roles):
-            try:
-                self.client.api.channels_messages_modify(channel=channel_id_to_change, message=message_ID_to_edit, content=edited_announcemented_message)
-                event.msg.reply('I have successfully changed the messaged the message you told me to.')
+        try:
+            self.client.api.channels_messages_modify(channel=channel_id_to_change, message=message_ID_to_edit, content=edited_announcemented_message)
+            event.msg.reply('I have successfully changed the messaged the message you told me to.')
 
-            except APIException:
-                event.msg.reply('I can\'t find a message with that ID in a channel with that ID. Please double check that you put the IDs in the correct order. It has to be `!edit <channel ID> <message ID> new message`')
-
-        else:
-            print('The user who tried to use this command does not have the appropriate role.')
-            return
+        except APIException:
+            event.msg.reply('I can\'t find a message with that ID in a channel with that ID. Please double check that you put the IDs in the correct order. It has to be `!edit <channel ID> <message ID> new message`')
 
 
     #Hopefully clear from the command name, but this command allows you to ping and announce to multiple DESKTOP roles simultaneously.
     @Plugin.command('multiping', parser=True)
     @Plugin.add_argument('-r', '--roles', help="all of the roles you want to ping")
     @Plugin.add_argument('-a', '--announcement', help="the message you want to send out to everyone.")
+    @command_wrapper(perm_lvl=2)
     def ping_multiple_roles(self, event, args):
 
         admin_only_channel = self.config.channel_IDs['mod_Channel']
@@ -121,129 +118,104 @@ class announce(Plugin):
         Channel_to_announce_in = self.config.channel_IDs['desktop']
 
 
-        #Make sure only an admin can do it
-        if self.checkPerms(event, "admin"):
-            if event.channel.id != admin_only_channel:
-                # make sure it's in the right channel
-                event.msg.reply("The command was not run in the proper channel").after(1).delete()
-                self.botlog(event, ":deny: "+str(event.msg.author)+" tried to use the Multiping command in the wrong channel.")
-                return
-
-            if "ios" in args.roles or "android" in args.roles:
-                event.msg.reply("This command can only be used for desktop roles. Linux, Windows, Mac and Canary.")
-                return
-
-            for pingable_role in self.config.role_IDs.keys():
-                if pingable_role in args.roles:
-                    #Variables
-
-                    Role_as_an_int = self.config.role_IDs[pingable_role]
-                    Role_as_a_string = str(self.config.role_IDs[pingable_role])
-                    Is_Role_Mentionable = event.guild.roles.get(Role_as_an_int).mentionable
-                    Role_To_Make_Mentionable = event.guild.roles.get(Role_as_an_int)
-                    message_to_announce = "<@&" + Role_as_a_string + "> " + args.announcement
-                    admin_only_channel = self.config.channel_IDs['mod_Channel']
-
-                    if Is_Role_Mentionable == False:
-                        Role_To_Make_Mentionable.update(mentionable=True)
-                    message_with_multiple_pings = message_with_multiple_pings + "<@&" + Role_as_a_string + "> "
-
-            if message_with_multiple_pings == "":
-                event.msg.reply("Something strange happened. Please let Dabbit know and try again.")
-                return
-            else:
-                message_with_multiple_pings = message_with_multiple_pings + args.announcement
-                self.bot.client.api.channels_messages_create(Channel_to_announce_in, message_with_multiple_pings)
-
-            for pingable_role in self.config.role_IDs.keys():
-
+        if event.channel.id != admin_only_channel:
+            # make sure it's in the right channel
+            event.msg.reply("The command was not run in the proper channel").after(1).delete()
+            log_to_bot_log(self.bot, ":deny: "+str(event.msg.author)+" tried to use the Multiping command in the wrong channel.")
+            return
+        if "ios" in args.roles or "android" in args.roles:
+            event.msg.reply("This command can only be used for desktop roles. Linux, Windows, Mac and Canary.")
+            return
+        for pingable_role in self.config.role_IDs.keys():
+            if pingable_role in args.roles:
                 #Variables
-                Role_To_Make_Unmentionable = event.guild.roles.get(self.config.role_IDs[pingable_role])
+                Role_as_an_int = self.config.role_IDs[pingable_role]
+                Role_as_a_string = str(self.config.role_IDs[pingable_role])
+                Is_Role_Mentionable = event.guild.roles.get(Role_as_an_int).mentionable
+                Role_To_Make_Mentionable = event.guild.roles.get(Role_as_an_int)
 
-                if Is_Role_Mentionable == True:
-                    Role_To_Make_Unmentionable.update(mentionable=False)
-                    self.botlog(event, ":exclamation: "+pingable_role +" was successfully set to unpingable.")
+                if Is_Role_Mentionable == False:
+                    Role_To_Make_Mentionable.update(mentionable=True)
+                message_with_multiple_pings = message_with_multiple_pings + "<@&" + Role_as_a_string + "> "
+        if message_with_multiple_pings == "":
+            event.msg.reply("Something strange happened. Please let Dabbit know and try again.")
+            return
+        else:
+            message_with_multiple_pings = message_with_multiple_pings + args.announcement
+            self.bot.client.api.channels_messages_create(Channel_to_announce_in, message_with_multiple_pings)
+        for pingable_role in self.config.role_IDs.keys():
+            #Variables
+            Role_To_Make_Unmentionable = event.guild.roles.get(self.config.role_IDs[pingable_role])
+            if Is_Role_Mentionable == True:
+                Role_To_Make_Unmentionable.update(mentionable=False)
+                log_to_bot_log(self.bot, ":exclamation: "+pingable_role +" was successfully set to unpingable.")
 
 
     @Plugin.command('tag', parser=True)
     @Plugin.add_argument('question_title', help="The title of the topic you want to post about.")
+    @command_wrapper(log=False)
     def questions_made_easy(self, event, args):
         #Checks to see if the topic in the list and then replies with the message in annouceBot.py
         args.question_title = args.question_title.lower()
-        if self.checkPerms(event, "mod"):
-            event.msg.delete()
-            if args.question_title in self.config.frequently_asked_questions.keys():
-                event.msg.reply(self.config.frequently_asked_questions[args.question_title])
-                self.botlog(event, ":notebook: "+str(event.msg.author)+" used the tag command for `"+args.question_title+"`.")
+        event.msg.delete()
+        if args.question_title in self.config.frequently_asked_questions.keys():
+            event.msg.reply(self.config.frequently_asked_questions[args.question_title])
+            log_to_bot_log(self.bot, ":notebook: "+str(event.msg.author)+" used the tag command for `"+args.question_title+"`.")
 
     #Quickly remove the ability for @everyone and Bug Hunters to post in specific channels when some issue is occurring
     @Plugin.command('lockdown', parser=True)
     @Plugin.add_argument('-c', '--channel_names', help="All the channels you want to lock down")
     @Plugin.add_argument('-r', '--reason', help="What's going on thats making you use this command.")
+    @command_wrapper(log=False)
     def emergency_lockdown(self, event, args):
-        if self.checkPerms(event, "mod"):
-            event.msg.delete()
-            for name, channelID in self.config.channels_to_lockdown.items():
-                # lock the channel if listed or when locking everything
-                if name in args.channel_names or args.channel_names == "all":
-                    self.botlog(event, ":lock: The "+name+" channel has been locked by "+str(event.msg.author)+" for the reason: "+args.reason+".")
-                    # grab the first (bug hunter or test role) for the queue, grab everyone (or whatever test role is there) for public channels
-                    rolename = "bug_hunter" if name == "bug" else "everyone"
-                    role = event.guild.roles[self.config.role_IDs_to_lockdown[rolename]]
-                    channel = event.guild.channels[channelID]
-                    channel.send_message(args.reason)
-                    # deny reactions and sending perms
-                    channel.create_overwrite(role, allow=0, deny=2112)
-            event.msg.reply("Lockdown command has successfully completed!")
+        event.msg.delete()
+        for name, channelID in self.config.channels_to_lockdown.items():
+            # lock the channel if listed or when locking everything
+            if name in args.channel_names or args.channel_names == "all":
+                log_to_bot_log(self.bot, ":lock: The "+name+" channel has been locked by "+str(event.msg.author)+" for the reason: "+args.reason+".")
+                # grab the first (bug hunter or test role) for the queue, grab everyone (or whatever test role is there) for public channels
+                rolename = "bug_hunter" if name == "bug" else "everyone"
+                role = event.guild.roles[self.config.role_IDs_to_lockdown[rolename]]
+                channel = event.guild.channels[channelID]
+                channel.send_message(args.reason)
+                # deny reactions and sending perms
+                channel.create_overwrite(role, allow=0, deny=2112)
+        event.msg.reply("Lockdown command has successfully completed!")
 
     # lifting the lockdown
     @Plugin.command('unlock', "<channels:str...>")
+    @command_wrapper()
     def lift_lockdown(self, event, channels):
-        if self.checkPerms(event, "mod"):
-            event.msg.delete()
-            for name, channelID in self.config.channels_to_lockdown.items():
-                # unlock the channel if listed or when unlocking everything
-                if name in channels or channels == "all":
-                    self.botlog(event, ":unlock: The "+name+" channel has been unlocked by "+str(event.msg.author)+".")
-                    # grab the first (bug hunter or test role) for the queue, grab everyone (or whatever test role is there) for public channels
-                    rolename = "bug_hunter" if name == "bug" else "everyone"
-                    role = event.guild.roles[self.config.role_IDs_to_lockdown[rolename]]
-                    channel = event.guild.channels[channelID]
-                    channel.create_overwrite(role, allow=2048 if name == "bug" else 0, deny=64)
-                    # clean up lockdown message, scan last 5 messages just in case
-                    limit = 5
-                    count = 0
-                    for message in channel.messages_iter(chunk_size=limit):
-                        if message.author.id == self.bot.client.api.users_me_get().id:
-                            message.delete()
-                        count = count + 1
-                        if count >= limit:
-                            break
-            event.msg.reply("Unlock command has successfully completed!")
+        event.msg.delete()
+        for name, channelID in self.config.channels_to_lockdown.items():
+            # unlock the channel if listed or when unlocking everything
+            if name in channels or channels == "all":
+                log_to_bot_log(self.bot, ":unlock: The "+name+" channel has been unlocked by "+str(event.msg.author)+".")
+                # grab the first (bug hunter or test role) for the queue, grab everyone (or whatever test role is there) for public channels
+                rolename = "bug_hunter" if name == "bug" else "everyone"
+                role = event.guild.roles[self.config.role_IDs_to_lockdown[rolename]]
+                channel = event.guild.channels[channelID]
+                channel.create_overwrite(role, allow=2048 if name == "bug" else 0, deny=64)
+                # clean up lockdown message, scan last 5 messages just in case
+                limit = 5
+                count = 0
+                for message in channel.messages_iter(chunk_size=limit):
+                    if message.author.id == self.bot.client.api.users_me_get().id:
+                        message.delete()
+                    count = count + 1
+                    if count >= limit:
+                        break
+        event.msg.reply("Unlock command has successfully completed!")
 
     @Plugin.command('a11y')
     def grant_role(self, event):
         if 441739649753546764 in event.member.roles:
             event.member.remove_role(441739649753546764)
-            self.botlog(event, ":thumbsdown: <@" +str(event.author.id)+ "> removed the A11y role from themselves.")
+            log_to_bot_log(self.bot, ":thumbsdown: <@" +str(event.author.id)+ "> removed the A11y role from themselves.")
             event.msg.reply("<@" +str(event.author.id)+ "> I have removed the A11y (Accessibility Role) from you. Use the same command again to add the role to yourself.").after(5).delete()
             event.msg.delete()
         else:
             event.member.add_role(441739649753546764)
-            self.botlog(event, ":thumbsup: <@" +str(event.author.id)+ "> added the A11y role to themselves.")
+            log_to_bot_log(self.bot, ":thumbsup: <@" +str(event.author.id)+ "> added the A11y role to themselves.")
             event.msg.reply("<@" +str(event.author.id)+ "> I have added the A11y (Accessibility Role) to you. Use the same command again to remove the role from yourself.").after(5).delete()
             event.msg.delete()
-
-
-    def checkPerms(self, event, type):
-        # get roles from the config
-        roles = getattr(self.config, str(type)+'_roles').values()
-        if any(role in roles for role in event.member.roles):
-            return True
-        event.msg.reply(":lock: You do not have permission to use this command!")
-        self.botlog(event, ":warning: "+str(event.msg.author)+" tried to use a command they do not have permission to use.")
-        return False
-
-    def botlog(self, event, message):
-        channel = event.guild.channels[self.config.channel_IDs['bot_log']]
-        channel.send_message(message)

--- a/commands/config.py
+++ b/commands/config.py
@@ -56,11 +56,6 @@ class AnnounceBotConfig(Config):
         'everyone': 411673927698350100
     }
     """
-    #DTesters IDs:
-    admin_roles = {
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
-    }
     role_IDs = {
         'android': 234838349800538112,
         'bug': 197042209038663680,
@@ -72,12 +67,6 @@ class AnnounceBotConfig(Config):
         'test': 441010616388419584
         }
 
-    mod_roles = {
-        'modinator': 440322144593772545,
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
-
-    }
 
     channel_IDs = {
         'android': 411645018105970699,
@@ -143,11 +132,6 @@ class AnnounceBotConfig(Config):
 
 class EventsPluginConfig(Config):
 
-    admin_roles = {
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
-    }
-
     role_IDs = {
         'android': 234838349800538112,
         'bug': 197042209038663680,
@@ -159,19 +143,12 @@ class EventsPluginConfig(Config):
         'test': 441010616388419584
         }
 
-    mod_roles = {
-        'modinator': 440322144593772545,
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
-    }
     emojis = {
         "yes": ":gearYes:459697272326848520",
         "no": ":gearNo:459697272314265600"
     }
 
     boards = {}
-
-    bot_log= 0
     event_channel = 0
 
 class ExperiencePluginConfig(Config):
@@ -182,7 +159,6 @@ class ExperiencePluginConfig(Config):
     mongodb_port = 27017
 
     bug_bot_user_id = 240545475118235648
-    dtesters_guild_id = 197038439483310086
 
     roles = {
         "admin": 197042322939052032,
@@ -191,17 +167,6 @@ class ExperiencePluginConfig(Config):
         "hunter": 197042209038663680,
         "fehlerjager": 268404368435445761,
         "squasher": 254347601288101888
-    }
-
-    admin_roles = {
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
-    }
-
-    mod_roles = {
-        'modinator': 440322144593772545,
-        'admin': 197042322939052032,
-        'employee': 197042389569765376
     }
 
     channels = {

--- a/util/GlobalHandlers.py
+++ b/util/GlobalHandlers.py
@@ -85,7 +85,7 @@ def handle_exception(event, bot, exception):
     embed.add_field(name="Original message", value=str(event.msg.content))
     embed.add_field(name="Channel", value="{} ({})".format(event.msg.channel.name, event.msg.channel.id))
     embed.add_field(name="Sender", value=str(event.msg.author))
-    # embed.add_field(name="Exception", value=str(exception))
+    embed.add_field(name="Exception", value=str(exception))
     embed.add_field(name="Stacktrace", value=str(traceback.format_exc()))
     embed.timestamp = datetime.utcnow().isoformat()
     embed.color = int('ff0000', 16)

--- a/util/GlobalHandlers.py
+++ b/util/GlobalHandlers.py
@@ -1,0 +1,102 @@
+import traceback
+from datetime import datetime
+
+from disco.types.message import MessageEmbed
+from disco.util import sanitize
+
+from util import Utils
+
+LOADED = False
+INFO = None
+
+# perm lvls:
+# 0: public
+# 1: mod+
+# 2: admin
+
+def is_hunter(member):
+    return has_role(member, [INFO["HUNTER_ROLE"]]) or is_mod(member)
+
+def is_mod(member):
+    return has_role(member, INFO["MOD_ROLES"]) or is_admin(member)
+
+def is_admin(member):
+    return has_role(member, INFO["ADMIN_ROLES"])
+
+def has_role(member, roles):
+    return any(role in roles for role in member.roles)
+
+PERM_CHECKS = [
+    is_hunter,
+    is_mod,
+    is_admin
+]
+
+#this handles all the command wrapping, with some defaults
+def command_wrapper(perm_lvl = 1, log=True, allowed_on_server = True, allowed_in_dm = False):
+    def func_receiver(func):
+        def func_wrapper(*args, **kwargs):
+            if not LOADED:
+                load()
+            #extract event param
+            plugin = args[0]
+            event = args[1]
+            #grab user from guild and validate permissions (this assumes the user is on there, but since the bot is not used anywhere else this is a safe assumption to make)
+            member = plugin.bot.client.api.guilds_members_get(INFO["SERVER_ID"], event.msg.author.id)
+            allowed = PERM_CHECKS[perm_lvl](member)
+            if not allowed:
+                log_to_bot_log(plugin.bot, ":warning: {} tried to use a command they do not have permission to use: ``{} ``".format(str(event.msg.author), sanitize.S(event.msg.content, escape_codeblocks=True)))
+                event.msg.reply(":lock: You do not have permission to use this command!").after(10).delete()
+                event.msg.delete()
+            else:
+                #can we execute here?
+                if (event.guild is not None and allowed_on_server) or (event.guild is None and allowed_in_dm):
+                    try:
+                        func(*args, **kwargs)
+                    except Exception as exception:
+                        handle_exception(event, plugin.bot, exception)
+                    else:
+                        if log:
+                            log_to_bot_log(plugin.bot, ":wrench: {} executed a command: {}".format(str(event.msg.author), sanitize.S(event.msg.content, escape_codeblocks=True)))
+        return func_wrapper
+    return func_receiver
+
+def handle_exception(event, bot, exception):
+    # catch everything and extract all info we can from the func arguments so we see what exactly was going on
+    print("Exception caught, extracting information")
+
+    print("====EXCEPTION====")
+    print(exception)
+
+    print("====STACKTRACE====")
+    print(traceback.format_exc())
+
+    print("====ORIGINAL MESSAGE====")
+    print(event.msg.content)
+
+    print("====SENDER====")
+    print(event.msg.author)
+
+    print("====Channel====")
+    print("{} ({})".format(event.msg.channel.name, event.msg.channel.id))
+
+    embed = MessageEmbed()
+    embed.title = "Exception caught"
+    embed.add_field(name="Original message", value=str(event.msg.content))
+    embed.add_field(name="Channel", value="{} ({})".format(event.msg.channel.name, event.msg.channel.id))
+    embed.add_field(name="Sender", value=str(event.msg.author))
+    # embed.add_field(name="Exception", value=str(exception))
+    embed.add_field(name="Stacktrace", value=str(traceback.format_exc()))
+    embed.timestamp = datetime.utcnow().isoformat()
+    embed.color = int('ff0000', 16)
+    log_to_bot_log(bot, embed=embed)
+
+def log_to_bot_log(bot, *args, **kwargs):
+    if not LOADED:
+        load()
+    bot.client.state.guilds[INFO["SERVER_ID"]].channels[INFO["LOG_CHANNEL"]].send_message(*args, **kwargs)
+
+def load():
+    global LOADED, INFO
+    INFO = Utils.fetchFromDisk("config/global")
+    LOADED = True


### PR DESCRIPTION
This PR also includes the changes from #25 to prevent merge conflicts and expands upon it

All commands are decorated now with a command_wrapper, this intercepts all call to the function, this allows doing all permissions checks on a more global lvl and get rid of all the related duplicate code (and add a few new things, like logging when commands are used)
a small behavior change: some commands would ignore a user when he did not have permissions, now all commands will tell the user they do not have permissions and delete both messages after 10s
The logging to botlog about someone using a command they do not have access to now also includes the command they tried to run

a global function to log to the botlog has also been added and remove that duplicated code

expanding on #25 since this handler intercepts the call and handles it, it is also a prime place to wrap the entire command in a try block for handling any potential errors, this is done in 2 ways
1) extract info and log to stdout like it used to do (sample output: https://gist.github.com/AEnterprise/519324bc206f9b81c5e470aab07485f3)
2) log the exception in to discord (example: https://imgur.com/a/lRH60v3)

all config entries about permissions and logging from existing configs can be removed, instead there is a new config called "global.json" needed in the configs folder to consolidate all of this
example config: https://gist.github.com/AEnterprise/4fbcbaf4359b1534df2098c3456c51f0
