### PR TITLE
fix colors being shifted

### DIFF
--- a/util/Pie.py
+++ b/util/Pie.py
@@ -18,19 +18,17 @@ def bake(sub, info, title, size='x-large', show_labels=True, title_size=20):
         "Reopened": 'purple',
         "Cannot Reproduce": 'orange'
     }
+
+    real_colors = []
     for k, v in info.items():
         if v == 0:
             empty.append(k)
+        elif k in colors.keys():
+            real_colors.append(colors[k])
     for e in empty:
         info.pop(e)
-    empty = []
-    for k in colors.keys():
-        if k not in info.keys():
-            empty.append(k)
-    for e in empty:
-        colors.pop(e)
     wedges, labels, labels2 = sub.pie(info.values(), labels=info.keys() if show_labels else None, autopct='%1.1f%%',
-                                      explode=[0.05] * len(info.keys()), colors=colors.values() if len(colors) == len(info) else None)
+                                      explode=[0.05] * len(info.keys()), colors=real_colors if len(real_colors) == len(info) else None)
     for i in range(len(info)):
         if len(colors) == len(info):
             labels[i].set_color(list(colors.values())[i])


### PR DESCRIPTION
pie chart colors where shifted if the order didn't match, this makes sure the right colors actually get applied to the right things (so approved is always green and not denied)