### PR TITLE
Adding fight and hug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 .DS_Store
-*.pyc
-config/
-.vscode/
-*.json
 .idea
+.vscode/*
+config/
+commands/testconfig.py
+*.pyc
+*.json
+*.png
 eventstats.json
 eval.py
-*.png
 config.yaml

--- a/commands/config.py
+++ b/commands/config.py
@@ -252,3 +252,33 @@ class NotifyPluginConfig(Config):
         'denied-bugs': 327914056591736834,
         'bug-approval-queue': 253923313460445184
     }
+
+class ChatInteractionsConfig(Config):
+    # Love should be easier to come across.
+    hug_cost = 5
+    fight_cost = 10
+
+    hug_msgs = [
+        'just gave you a big big hug!'
+    ]
+
+    fight_msgs = [
+        ", but instead slipped on some jam and fell right into Dabbit, who is not pleased.", 
+        " with a transformer.", 
+        ", but creates a black hole and gets sucked in.", 
+        " with poutine.", 
+        ", but they slipped on a banana peel", 
+        " and in the end, the only victor was the coffin maker.", 
+        ", and what a fight it is!  Whoa mama!", 
+        ", with two thousand blades!", 
+        ", but he fell into a conveniently placed manhole!", 
+        ", but they tripped over a rock and fell in the ocean", 
+        ", but they hurt themselves in confusion", 
+        ". HADOUKEN!", 
+        " with a pillow", 
+        " with a large fish", 
+        ", but they stumbled over their shoelaces", 
+        ", but they missed", 
+        " with a burnt piece of toast", 
+        ", but it wasn't every effective"
+    ]

--- a/commands/config.py
+++ b/commands/config.py
@@ -1,6 +1,5 @@
 from disco.bot import Config
 
-
 class AnnounceBotConfig(Config):
     """
     admin_roles = {
@@ -55,17 +54,6 @@ class AnnounceBotConfig(Config):
         'everyone': 411673927698350100
     }
     """
-    role_IDs = {
-        'android': 234838349800538112,
-        'bug': 197042209038663680,
-        'canary': 351008402052481025,
-        'ios': 234838392464998402,
-        'linux': 278229255169638410,
-        'mac': 351008099978706944,
-        'windows': 351008373669494794,
-        'test': 441010616388419584
-        }
-
 
     channel_IDs = {
         'android': 411645018105970699,
@@ -94,7 +82,6 @@ class AnnounceBotConfig(Config):
 
 
     frequently_asked_questions = {
-
         'suggestions': "Thanks for wanting to improve Discord! When it comes to making suggestions, you have two options: You can head over to <https://feedback.discordapp.com> or join the feedback community over at https://discord.gg/discord-feedback",
         'raids': "If a server you're in is currently being raided, there is nothing that can be done on this server to help. The only people that can aid you are our Trust and Safety team whom you can contact via https://dis.gd/request."
             + "\nFor fastest turn around time, read over this article <https://dis.gd/HowToReport>.",
@@ -119,7 +106,6 @@ class AnnounceBotConfig(Config):
         'support': 'You can reach support at https://dis.gd/contact for all your questions and help with figuring out problems (even in your native language if you prefer).',
         'lazy': 'Lazy guilds are guilds where you can see the offline members in the list. This does ***not*** have a negative impact on performance or loading times, quite the opposite. You can grab one of the desktop roles listed in <#342060723721207810> section 4 which will give you access to the desktop-announcements channel, where you can read more about it.',
         'hunter': 'You can acquire the Bug Hunter role by submitting a bug with the bot and getting it approved. For more in-depth instructions, please read through <#342043548369158156>'
-
     }
 
     event_stats_filename = "eventstats.json" # event stats are saved to this location.
@@ -130,18 +116,6 @@ class AnnounceBotConfig(Config):
     }
 
 class EventsPluginConfig(Config):
-
-    role_IDs = {
-        'android': 234838349800538112,
-        'bug': 197042209038663680,
-        'canary': 351008402052481025,
-        'ios': 234838392464998402,
-        'linux': 278229255169638410,
-        'mac': 351008099978706944,
-        'windows': 351008373669494794,
-        'test': 441010616388419584
-        }
-
     emojis = {
         "yes": ":gearYes:459697272326848520",
         "no": ":gearNo:459697272314265600"
@@ -152,23 +126,6 @@ class EventsPluginConfig(Config):
 
 class ExperiencePluginConfig(Config):
 
-    mongodb_username = "mongodb"
-    mongodb_password = "password"
-    mongodb_host = "localhost"
-    mongodb_port = 27017
-
-    bug_bot_user_id = 240545475118235648
-    dtesters_guild_id = 197038439483310086
-
-    roles = {
-        "admin": 197042322939052032,
-        "mod": 440322144593772545,
-        "employee": 197042389569765376,
-        "hunter": 197042209038663680,
-        "fehlerjager": 268404368435445761,
-        "squasher": 254347601288101888
-    }
-
     channels = {
         "bot_log": 0,
         "prize_log": 0,
@@ -178,8 +135,8 @@ class ExperiencePluginConfig(Config):
     rewards = {
         "approve_deny": 5,
         "canrepro_cantrepro": 3,
+        "attach": 5,
         "submit": 25,
-        "attach": 5
     }
 
     reward_limits = {
@@ -207,7 +164,6 @@ class ExperiencePluginConfig(Config):
                            "Discord profile!"
         }
     ]
-
 
 class GuideConfig(Config):
     guides = {
@@ -245,8 +201,6 @@ class GuideConfig(Config):
     }
 
 class NotifyPluginConfig(Config):
-    bug_bot_id = 240545475118235648
-
     channels = {
         'bot-log': 455874979146235916,
         'denied-bugs': 327914056591736834,

--- a/commands/interactions.py
+++ b/commands/interactions.py
@@ -1,0 +1,100 @@
+#Welcome to the ChatInteractionPlugin!
+#Most of the code here is proudly borrowed from experience.py due to the bots current setup. 
+#If one person got it right, I won't reinvent the wheel.
+import random
+
+from disco.bot import Plugin
+from pymongo import MongoClient
+
+from commands.config import ChatInteractionsConfig
+
+from util.GlobalHandlers import command_wrapper
+
+@Plugin.with_config(ChatInteractionsConfig)
+class ChatInteractionPlugin(Plugin):
+
+    def load(self, ctx):
+        super(ChatInteractionPlugin, self).load(ctx)
+        self.client = MongoClient(self.config.mongodb_host, self.config.mongodb_port,
+                                  username=self.config.mongodb_username,
+                                  password=self.config.mongodb_password)
+        self.database = self.client.get_database("experience")
+        self.users = self.database.get_collection("users")
+        self.actions = self.database.get_collection("actions")
+        self.purchases = self.database.get_collection("purchases")
+ 
+    def unload(self, ctx):
+        self.users.save()
+        self.actions.save()
+        super(ChatInteractionPlugin, self).load(ctx)
+
+    def get_user(self, id):
+        """
+        Get a user by their ID
+        :param id: the user's ID
+        :return: a dictionary containing the user's information
+        """
+        result = self.users.find_one({
+            "user_id": str(id)
+        })
+
+        if result is None:
+            insert_result = self.users.insert_one({
+                "user_id": str(id),
+                "xp": 0
+            })
+            return self.users.find_one({"_id": insert_result.inserted_id})
+
+        return result
+
+    def get_id(self, id_str):
+        if id_str.isdigit():
+            return int(id_str)
+        elif id_str.startswith("<@") and id_str.endswith(">"):
+            snowflake_str = id_str[2:-1]
+            if snowflake_str.startswith("!"):
+                snowflake_str = id_str[3:-1]
+            return snowflake_str
+        else:
+            # invalid, returning None
+            return None
+
+    @Plugin.command("hug", "<user:user>")
+    @command_wrapper(perm_lvl=1)
+    def hug(self, event, user):
+        member = event.guild.get_member(user)
+
+        user = self.get_user(event.msg.author.id)
+
+        if user["xp"] < self.config.hug_cost:
+            event.msg.reply(":no_entry_sign: Sadly, you don't have enough XP to hug :(")
+            return
+
+        self.users.update_one({
+            "user_id": str(event.msg.author.id)
+        }, {
+            "$set": {
+                "xp": user["xp"] - self.config.hug_cost
+            }
+        })
+        event.msg.reply("<@{}>, {} {}".format(member.id, event.msg.author.username, random.choice(self.config.hug_msgs)))
+
+    @Plugin.command("fight", "<user:user>")
+    @command_wrapper(perm_lvl=1)
+    def fight(self, event, user):
+        member = event.guild.get_member(user)
+
+        user = self.get_user(event.msg.author.id)
+
+        if user["xp"] < self.config.hug_cost:
+            event.msg.reply(":no_entry_sign: Uhoh! You can't start a fight because you don't have enough XP :(")
+            return
+
+        self.users.update_one({
+            "user_id": str(event.msg.author.id)
+        }, {
+            "$set": {
+                "xp": user["xp"] - self.config.fight_cost
+            }
+        })
+        event.msg.reply("{} is fighting <@{}>{}".format(event.msg.author.username, member.id, random.choice(self.config.fight_msgs)))        

--- a/commands/notify.py
+++ b/commands/notify.py
@@ -90,7 +90,7 @@ class NotifyPlugin(Plugin):
         queue = event.guild.channels[self.config.channels['bug-approval-queue']]
         reports = []
         for message in queue.messages:
-            if message.author.id == self.config.bug_bot_id:
+            if message.author.id == self.config.bug_bot_user_id:
                 search = re.findall(r'(?<=Report\sID:\s\*{2})[0-9]+', message.content)
                 if search:
                     report_id = int(search[-1])
@@ -175,7 +175,7 @@ class NotifyPlugin(Plugin):
 
     @Plugin.listen('MessageCreate')
     def on_message_create(self, event):
-        if event.author.id != self.config.bug_bot_id:
+        if event.author.id != self.config.bug_bot_user_id:
             return
         action = None
         # Bot Log - covers almost all events

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -7,6 +7,24 @@ bot:
     mongodb_password: "password"
     mongodb_host: "localhost"
     mongodb_port: 27017
+    bug_bot_user_id: 240545475118235648
+    dtesters_guild_id: 197038439483310086
+    role_IDs:
+      admin: 197042322939052032
+      mod: 440322144593772545
+      employee: 197042389569765376
+      hunter: 197042209038663680
+      fehlerjager: 268404368435445761
+      squasher: 254347601288101888
+      android: 234838349800538112
+      bug: 197042209038663680
+      canary: 351008402052481025
+      ios: 234838392464998402
+      linux: 278229255169638410
+      mac: 351008099978706944
+      windows: 351008373669494794
+      test: 441010616388419584
+        
   plugins:
     - commands.announce
     - commands.events

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -15,4 +15,4 @@ bot:
     - commands.guide
     - commands.notify
     - commands.mentor
-
+    - commands.interactions


### PR DESCRIPTION
This PR adds basic implementation of the `ChatInteractionsPlugin`. 

The original list of things required was:

- [x] "it should take a userID or @ menton as arguments"
![](https://u.dejaydev.com/5b931.png)
- [x] All strings are randomly chosen from config
- [x] The amount of xp that’s cost should also be configurable
- [x] print to the bot log
- [ ] Daily use limits to prevent spam
    - (I haven't learned how to do this with this bots setup its vry scary)

This PR also suggests that config.py is condensed by making use of the config.yaml.

Disco offers shared_config as of v0.0.12, and config.py was very hard to navigate with multiple duplicate variables. 35 lines were spared in config.py by this change.

#### Note: 
Should this PR be merged, before putting the bot online please copy the example config and reconfigure.