### PR TITLE
Queue Summary

### DIFF
--- a/commands/config.py
+++ b/commands/config.py
@@ -123,15 +123,15 @@ class EventsPluginConfig(Config):
 
     boards = {}
     event_channel = 0
-    queue_summary = {
-        "title": "Summary",
-        "message": [],
-        "channel": 0,
-        "color": '808080'
-    }
 
 class StatsPluginConfig(Config):
     queue_channel = 253923313460445184
+    queue_summary = {
+        "title": "Bug Approval Queue Summary",
+        "message": [],
+        "channel": 0,
+        "color": '#7289DA'
+    }
 
 class ExperiencePluginConfig(Config):
 

--- a/commands/config.py
+++ b/commands/config.py
@@ -124,6 +124,9 @@ class EventsPluginConfig(Config):
     boards = {}
     event_channel = 0
 
+class StatsPluginConfig(Config):
+    queue_channel = 253923313460445184
+
 class ExperiencePluginConfig(Config):
 
     channels = {

--- a/commands/config.py
+++ b/commands/config.py
@@ -123,6 +123,12 @@ class EventsPluginConfig(Config):
 
     boards = {}
     event_channel = 0
+    queue_summary = {
+        "title": "Summary",
+        "message": [],
+        "channel": 0,
+        "color": '808080'
+    }
 
 class StatsPluginConfig(Config):
     queue_channel = 253923313460445184

--- a/commands/stats.py
+++ b/commands/stats.py
@@ -95,7 +95,11 @@ class StatsPlugin(Plugin):
             pass
 
     def call_arguments(self, argument_type, params, reports):
-        return getattr(self, f"argument_{argument_type}")(**{'params': params, 'reports': reports})
+        attr_name = f"argument_{argument_type}"
+        if hasattr(self, attr_name):
+            return getattr(self, attr_name)(**{'params': params, 'reports': reports})
+        else:
+            return f"*Unknown argument {argument_type}*"
 
     def argument_oldest_report(self, params, reports: dict):
         r = reduce(list.__add__, reports.values()) if params[0] == "all" \

--- a/commands/stats.py
+++ b/commands/stats.py
@@ -1,4 +1,6 @@
 import re
+from datetime import datetime, timedelta
+from functools import reduce
 
 from disco.bot import Plugin
 from disco.bot.command import CommandEvent
@@ -14,6 +16,7 @@ class StatsPlugin(Plugin):
     def __init__(self, bot, config):
         super().__init__(bot, config)
         self.channel_regex = re.compile('<#([0-9]{17,18})>\\s.*Reported:', re.MULTILINE)
+        self.argument_regex = re.compile('{{([A-Za-z_]+):?([A-Za-z0-9,_/]+)?}}', re.MULTILINE)
 
     @Plugin.command('reportingChannel', '<chan_id:snowflake> <message_id:snowflake>')
     def reporting_channel(self, event: CommandEvent, chan_id, message_id):
@@ -34,7 +37,7 @@ class StatsPlugin(Plugin):
         if reports is not None:
             body = ""
             for chan, reports in reports.items():
-                to_add = f"<#{chan}> - **{len(reports)} report" + ("s" if len(reports) > 1 else "")+"**\n"
+                to_add = f"<#{chan}> - **{len(reports)} report" + ("s" if len(reports) > 1 else "") + "**\n"
                 if len(to_add + body) > 2000:
                     event.msg.reply(body)
                     body = ""
@@ -42,6 +45,10 @@ class StatsPlugin(Plugin):
             event.msg.reply(body)
         else:
             event.msg.reply("no reports in the queue?")
+
+    @Plugin.command('argTest', '<msg:str...>')
+    def arg_test(self, event: CommandEvent, msg: str):
+        event.msg.reply(self.parse_message(msg, self.get_all_bug_reports()))
 
     def get_reporting_channel(self, msg: Message):
         match = self.channel_regex.findall(msg.content)
@@ -64,7 +71,53 @@ class StatsPlugin(Plugin):
             if bug_report_channel is None:
                 continue  # Failed the Regex.
             if bug_report_channel not in reports.keys():
-                reports[bug_report_channel] = [message.id]
+                reports[bug_report_channel] = [message]
             else:
-                reports[bug_report_channel].append(message.id)
+                reports[bug_report_channel].append(message)
         return reports
+
+    def parse_message(self, msg, reports):
+        parsed = msg
+        for match in self.argument_regex.finditer(msg):
+            arg = match.group(0)
+            name = match.group(1).lower()
+            args = match.group(2).lower().split(",")
+            self.bot.log.info(f"Parsing {arg} -- Name: {name}, args: {args}")
+            resp = self.call_arguments(name, args, reports)
+            parsed = parsed.replace(arg, resp)
+        return parsed
+
+    def call_arguments(self, argument_type, params, reports):
+        self.bot.log.info(f"Executing argument_{argument_type}")
+        return getattr(self, f"argument_{argument_type}")(**{'params': params, 'reports': reports})
+
+    def argument_oldest_report(self, params, reports: dict):
+        r = reduce(list.__add__, reports.values()) if params[0] == "all" \
+            else reports[params[0]] if params[0] in reports.keys() else []
+        if len(r) == 0:
+            return ""
+        report = sorted(r, key=lambda x: x.id)[0]
+        return f"https://discordapp.com/channels/{report.guild.id}/{report.channel.id}/{report.id}"
+
+    def argument_total_reports(self, params, reports: dict):
+        r = reduce(list.__add__, reports.values()) if params[0] == "all" \
+            else reports[params[0]] if params[0] in reports.keys() else []
+        return str(len(r))
+
+    def argument_stale_reports(self, params, reports: dict):
+        r = reduce(list.__add__, reports.values()) if params[0] == "all" \
+            else reports[params[0]] if params[0] in reports.keys() else []
+        hours = params[1]
+        target = datetime.today() - timedelta(hours=int(hours))
+        target_snowflake = snowflake.from_datetime(target)
+
+        stale_reports = []
+        for report in r:
+            if report.id < target_snowflake:
+                if report.edited_timestamp is not None:
+                    if report.edited_timestamp < target:
+                        stale_reports.append(report)
+                else:
+                    stale_reports.append(report)
+
+        return str(len(stale_reports))

--- a/commands/stats.py
+++ b/commands/stats.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime, timedelta
 from functools import reduce
 
+from disco.api.http import APIException
 from disco.bot import Plugin
 from disco.bot.command import CommandEvent
 from disco.types import Message, Channel
@@ -91,8 +92,12 @@ class StatsPlugin(Plugin):
             chan.send_message(embed=embed)
         else:
             # Edit the message with the new content
-            self.summary_message.edit(embed=embed)
-            pass
+            try:
+                self.summary_message.edit(embed=embed)
+            except APIException:
+                # The message got deleted?
+                self.summary_message = None
+                self.send_or_update_message(embed)
 
     def call_arguments(self, argument_type, params, reports):
         attr_name = f"argument_{argument_type}"

--- a/commands/stats.py
+++ b/commands/stats.py
@@ -3,6 +3,7 @@ import re
 from disco.bot import Plugin
 from disco.bot.command import CommandEvent
 from disco.types import Message, Channel
+from disco.util import snowflake
 
 from commands.config import StatsPluginConfig
 
@@ -12,7 +13,7 @@ class StatsPlugin(Plugin):
 
     def __init__(self, bot, config):
         super().__init__(bot, config)
-        self.channel_regex = re.compile('<#([0-9]{17,18})>\s.*Reported:', re.MULTILINE)
+        self.channel_regex = re.compile('<#([0-9]{17,18})>\\s.*Reported:', re.MULTILINE)
 
     @Plugin.command('reportingChannel', '<chan_id:snowflake> <message_id:snowflake>')
     def reporting_channel(self, event: CommandEvent, chan_id, message_id):
@@ -23,9 +24,47 @@ class StatsPlugin(Plugin):
             return
         else:
             chan = self.get_reporting_channel(msg)
-            event.msg.reply(f"The message was reported in {chan} <#{chan}>")
+            t = snowflake.to_datetime(message_id)
+            event.msg.reply(
+                f"The message was reported in {chan} <#{chan}> and was reported on {t.strftime('%Y-%m-%d %H:%m:%S')}")
+
+    @Plugin.command('reports')
+    def reports(self, event: CommandEvent):
+        reports = self.get_all_bug_reports()
+        if reports is not None:
+            body = ""
+            for chan, reports in reports.items():
+                to_add = f"<#{chan}> - **{len(reports)} report" + ("s" if len(reports) > 1 else "")+"**\n"
+                if len(to_add + body) > 2000:
+                    event.msg.reply(body)
+                    body = ""
+                body += to_add
+            event.msg.reply(body)
+        else:
+            event.msg.reply("no reports in the queue?")
 
     def get_reporting_channel(self, msg: Message):
-        print(msg.content)
         match = self.channel_regex.findall(msg.content)
         return match[0]
+
+    def get_all_bug_reports(self):
+        guild = self.bot.client.state.guilds[self.config.dtesters_guild_id]
+        if guild is None:
+            self.bot.log.error("Failed to find the guild")
+            return None  # We're not in DTesters?
+        channel: Channel = guild.channels[self.config.queue_channel]
+        if channel is None:
+            self.bot.log.error("Failed to find the bug approval queue channel")
+            return None  # The guild doesn't have the configured bug-approval-queue channel
+        reports = {}
+        for message in channel.messages:
+            if message.author.id != self.config.bug_bot_user_id:
+                continue
+            bug_report_channel = self.get_reporting_channel(message)
+            if bug_report_channel is None:
+                continue  # Failed the Regex.
+            if bug_report_channel not in reports.keys():
+                reports[bug_report_channel] = [message.id]
+            else:
+                reports[bug_report_channel].append(message.id)
+        return reports

--- a/commands/stats.py
+++ b/commands/stats.py
@@ -1,0 +1,31 @@
+import re
+
+from disco.bot import Plugin
+from disco.bot.command import CommandEvent
+from disco.types import Message, Channel
+
+from commands.config import StatsPluginConfig
+
+
+@Plugin.with_config(StatsPluginConfig)
+class StatsPlugin(Plugin):
+
+    def __init__(self, bot, config):
+        super().__init__(bot, config)
+        self.channel_regex = re.compile('<#([0-9]{17,18})>\s.*Reported:', re.MULTILINE)
+
+    @Plugin.command('reportingChannel', '<chan_id:snowflake> <message_id:snowflake>')
+    def reporting_channel(self, event: CommandEvent, chan_id, message_id):
+        chan: Channel = event.guild.channels.get(chan_id)
+        msg = chan.get_message(message_id)
+        if msg is None:
+            event.msg.reply(f"The message with id ${message_id} was not found!")
+            return
+        else:
+            chan = self.get_reporting_channel(msg)
+            event.msg.reply(f"The message was reported in {chan} <#{chan}>")
+
+    def get_reporting_channel(self, msg: Message):
+        print(msg.content)
+        match = self.channel_regex.findall(msg.content)
+        return match[0]

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -34,3 +34,4 @@ bot:
     - commands.notify
     - commands.mentor
     - commands.interactions
+    - commands.stats


### PR DESCRIPTION
Per [this](https://trello.com/c/L1gt895d/), I've added Bug Approval Queue summary features.

Every 5 minutes, the queue channel (settable in the config) will be polled and all messages by Bug-Bot will be parsed for the original channel that the report came from. This data will then be parsed and a message in a configurable channel will be updated accordingly. All aspects (Title, color, and content) of the embed can be customized in the configuration file and various placeholders are replaced with data retrieved from the queue channel.

## Example Usage
Below is an example of what the summary message could look like
![image](https://user-images.githubusercontent.com/1572296/47609865-4658a280-d9fc-11e8-98db-f49f39b213b5.png)

## Configuration
The above message can be reproduced with the following configuration:
```json
{
  "queue_channel": 504057052574777345,
  "queue_summary": {
    "message": [
      "Blah blah blah here are the stats for the queue",
      "There are **{{total_reports:all}}** reports in the queue right now.",
      "- **{{total_reports:504057281432911903}}** Android \n - **{{total_reports:504057333362720782}}** iOS",
      "- **{{total_reports:504057350576013332}}** Desktop \n - **{{total_reports:504057365922840586}}** Linux",
      "[Oldest Report]({{oldest_report:all}})"
    ],
    "channel": 504769070730706984,
    "title": "Bug Approval Queue Statistics",
    "color": "#7289DA"
  }
}
```
### Configuration Options
`queue_channel` - The ID of the bug approval queue channel
`queue_summary.message` - An array of strings that make up the queue summary message. Each element in the array is appended as a new line to the summary message with placeholders (discussed below) replaced appropriately.
`queue_summary.channel` - The channel that the queue summary embed is posted to. The bot will find the _most recent_ message by itself posted there and edit it as appropriate
`queue_summary.title` - The title of the embed
`queue_summary.color` - The color of the embed

## Placeholders
Placeholders are used to insert dynamically determined data about the various bugs in the queue into the message. Each placeholder follows the following format: `{{<name>:<arguments>}}`. Each argument is separated by a comma (`,`). In all placeholders currently implemented, the first argument is the channel of reports to consider or `all` for all reports.

The following placeholders and their usage are available:

| Placeholder | Description | Example Usage |
| --- | --- | --- |
| `total_reports` | The total number of reports in the queue | `{{total_reports:all}}` - All reports in the queue. `{{total_reports:<channel>}}` - All reports in the given channel |
| `oldest_report` | A jump link to the oldest report in the queue | `{{oldest_report:all}}` - The oldest report out of all the reports in the queue `{{oldest_report:<channel>}}` - The oldest report originating from the given channel |
| `stale_reports` | The number of reports that have gone stale (No activity in X hours) | `{{stale_reports:all,<time>}}` - The number of reports that haven't had any activity in the given time (in hours). `{{stale_reports:<channel>,<time>}}` - The number of reports that haven't had any activity from the given channel in the given time (in hours)

## Commands
Only one command is provided for moderators and above: `+stats update` which forces an update of the statistics

## Caveats
The one caveat that I ran into when working on this feature was a way to get the stats to update when the bot starts up. Various options that I have tried did not work as expected, so that feature is left out. The bot _does_, however, update statistics every 5 minutes.