### PR TITLE
Add command to check XP cooldowns

### DIFF
--- a/commands/config.py
+++ b/commands/config.py
@@ -164,6 +164,12 @@ class ExperiencePluginConfig(Config):
         "submit": 200
     }
 
+    cooldown_map = {
+        "approve_deny": "Approve/Deny",
+        "canrepro_cantrepro": "Can/Can't Repro",
+        "submit": "Submit"
+    }
+
     store = [
         {
             "title": "Bug Squasher role (for a week)",


### PR DESCRIPTION
Adds the `+cooldowns` command (DM only, alias: `+xpcap`) as per [this](https://trello.com/c/cIkNka0y) which tells you how many queue actions you've performed in the past day (that count towards XP) and how long until they start cooling down.

It also uses the `cooldown_map` dict in the config to control how/if an action should be displayed in the embed.

![cooldowns](https://user-images.githubusercontent.com/358657/48869058-b841c300-edd3-11e8-9d9d-36248cd8b143.PNG)


