### PR TITLE
Switch to gearboat from rowboat.

### DIFF
--- a/commands/answer_questions.py
+++ b/commands/answer_questions.py
@@ -13,7 +13,7 @@ class answer_questions(Plugin):
 
     bot_IDs = {
       'testbot': 422786385015996439,
-      'rowboat': 232921983317180416,
+      'gearboat': 520953716610957312,
       'outboard': 501816123507998730,
       'evilDabbit': 413393370770046976,
       'bugbot': 240545475118235648


### PR DESCRIPTION
Since rowboat is no longer used in DTesters, and Gearboat is now here, this should be fixed.