### PR TITLE
Minor adjustment to fight message

### DIFF
--- a/commands/config.py
+++ b/commands/config.py
@@ -231,7 +231,7 @@ class ChatInteractionsConfig(Config):
         " and in the end, the only victor was the coffin maker.",
         ", and what a fight it is!  Whoa mama!",
         ", with two thousand blades!",
-        ", but he fell into a conveniently placed manhole!",
+        ", but they fell into a conveniently placed manhole!",
         ", but they tripped over a rock and fell in the ocean",
         ", but they hurt themselves in confusion",
         ". HADOUKEN!",


### PR DESCRIPTION
Noticed this while looking through all of the fight messages.

Every fight message that addresses someone uses "they", except one that uses "he"
I changed this so it doesn't seem awkward and to remain gender-neutral.